### PR TITLE
feat: rename the project and dependencies for the equinix-labs org

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - run: find ${{ runner.temp }}/.. -ls 
     - id: metal-project
-      uses: equinix-labs/metal-project-action@v0.9.0
+      uses: equinix-labs/metal-project-action@v0.11.0
     - name: Use the Project SSH Key environment (display it)
       run: |
         echo ${{ env.METAL_SSH_PRIVATE_KEY_FILE }}
@@ -27,6 +27,6 @@ jobs:
         PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         PROJECT_NAME: ${{ steps.metal-project.outputs.projectName }}
     - name: Project Delete
-      uses: equinix-labs/metal-sweeper-action@v0.3.0
+      uses: equinix-labs/metal-sweeper-action@v0.4.0
       env:
         METAL_PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - run: find ${{ runner.temp }}/.. -ls 
     - id: metal-project
-      uses: displague/metal-project-action@v0.9.0
+      uses: equinix-labs/metal-project-action@v0.9.0
     - name: Use the Project SSH Key environment (display it)
       run: |
         echo ${{ env.METAL_SSH_PRIVATE_KEY_FILE }}
@@ -27,6 +27,6 @@ jobs:
         PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         PROJECT_NAME: ${{ steps.metal-project.outputs.projectName }}
     - name: Project Delete
-      uses: displague/metal-sweeper-action@v0.3.0
+      uses: equinix-labs/metal-sweeper-action@v0.3.0
       env:
         METAL_PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   project:
     env:
-      METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+      METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     runs-on: ubuntu-latest
     # TODO(displague) PROJECT_ID should also be globalized
     steps:

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     # TODO(displague) PROJECT_ID should also be globalized
     steps:
-    - run: find ${{ runner.temp }}/.. -ls 
     - id: metal-project
       uses: equinix-labs/metal-project-action@v0.11.0
     - name: Use the Project SSH Key environment (display it)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Example of Equinix Metal Github Actions for creating and clearing [Equinix Metal
 
 This project demonstrates the use of two Github Actions:
 
-* <https://github.com/displague/metal-project-action>
-* <https://github.com/displague/metal-sweeper-action>
+* <https://github.com/equinix-labs/metal-project-action>
+* <https://github.com/equinix-labs/metal-sweeper-action>
 
 The `.github/workflows/metal.yml` workflow invokes these two actions to first create an Equinix Metal project, and then to delete that project.
 
@@ -20,19 +20,19 @@ name: 'metal'
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 jobs:
   project:
     runs-on: ubuntu-latest
-    # TODO(displague) PACKET_AUTH_TOKEN should be defined once, globally
+    # TODO(displague) METAL_AUTH_TOKEN should be defined once, globally
     # TODO(displague) PROJECT_ID should also be globalized
     steps:
     - id: metal-project
-      uses: displague/metal-project-action@v0.4.0
+      uses: equinix-labs/metal-project-action@v0.4.0
       env:
-        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     - name: Use the Project ID (display it)
       run: |
         echo Equinix Metal Project "$PROJECT_NAME" has ID "$PROJECT_ID"
@@ -40,10 +40,10 @@ jobs:
         PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         PROJECT_NAME: ${{ steps.metal-project.outputs.projectName }}
     - name: Project Delete
-      uses: displague/metal-sweeper-action@v0.2.0
+      uses: equinix-labs/metal-sweeper-action@v0.2.0
       env:
-        PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
-        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+        METAL_PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
 ```
 
 ## Reasons
@@ -62,4 +62,4 @@ There are a number of benefits to using an ephemeral token with least privilege,
 * The Project Key can be disposed of with the disposal of the project
 * Leaked project keys have a narrow window of usability and minimized splash radius
 
-In [this example project](https://github.com/displague/metal-actions-example/), we take advantage of a Github Workflow that creates a random project, performs some project specific tasks, and then deletes the project. This workflow (and the "metal-project-action" which creates the project) benefit from the ability to generate and exchange a powerful (and therefor dangerous) user API token with a confined and less-dangerous project API token for the Github actions that should be confined to work within the generated project.
+In [this example project](https://github.com/equinix-labs/metal-actions-example/), we take advantage of a Github Workflow that creates a random project, performs some project specific tasks, and then deletes the project. This workflow (and the "metal-project-action" which creates the project) benefit from the ability to generate and exchange a powerful (and therefor dangerous) user API token with a confined and less-dangerous project API token for the Github actions that should be confined to work within the generated project.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     # TODO(displague) PROJECT_ID should also be globalized
     steps:
     - id: metal-project
-      uses: equinix-labs/metal-project-action@v0.4.0
+      uses: equinix-labs/metal-project-action@v0.11.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     - name: Use the Project ID (display it)
@@ -40,8 +40,8 @@ jobs:
         PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         PROJECT_NAME: ${{ steps.metal-project.outputs.projectName }}
     - name: Project Delete
-      uses: equinix-labs/metal-sweeper-action@v0.2.0
-      env:
+      uses: equinix-labs/metal-sweeper-action@v0.4.0
+      with:
         METAL_PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
 ```


### PR DESCRIPTION
Moves the project docs and dependencies to equinix-labs from displague, along with
* https://github.com/equinix-labs/metal-sweeper-action/pull/9
* https://github.com/equinix-labs/metal-project-action/pull/11


This example update should be deferred until:
- [x] The action tags references in this repo should also be updated to match releases of the above changes.

TODO (later):
- [x] the other projects have been updated for https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.
- [ ] Should we be using `with` instead of `env` on the action calls? (do we have to change the go code to receive the parameters that way?)

