### PR TITLE
docs: pin action versions and link to parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
-# Workshop: Equinix Labs
-
-<!---
-Using this template in a new project? See CONTIBUTING.md for help.
---->
+# Workshop: GitHub Actions on Equinix Metal
 
 This repo contains instructions for the ["Equinix Metal GitHub Actions" workshop](https://equinix-labs.github.io/metal-github-actions-workshop/).
 
 To view the workshop, visit <https://equinix-labs.github.io/metal-github-actions-workshop/>
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,6 @@ This workshop is split into two parts:
 
 | Part | Title | Duration |
 | - | - | - |
-| 1 | Setup | 10 minutes |
-| 2 | Create & Run GitHub Actions Workflow | 10 minutes |
-
+| 1 | [Setup](./parts/part1.md) | 10 minutes |
+| 2 | [Create a GitHub Actions workflow](./parts/part2.md) | 10 minutes |
+| 3 | [Understanding your GitHub Actions workflow](./parts/part3.md) | 10 minutes |

--- a/docs/parts/part2.md
+++ b/docs/parts/part2.md
@@ -57,7 +57,7 @@ jobs:
     steps:
     - name: Create temporary project
       id: metal-project
-      uses: equinix-labs/metal-project-action@main
+      uses: equinix-labs/metal-project-action@v0.14.1
       with:
         userToken: ${{ secrets.METAL_AUTH_TOKEN }}
     - name: Use the Project SSH Key outputs (display it)
@@ -74,7 +74,7 @@ jobs:
         PROJECT_ID: ${{ steps.metal-project.outputs.projectID }}
         PROJECT_NAME: ${{ steps.metal-project.outputs.projectName }}
     - name: Create device in temporary project
-      uses: equinix-labs/metal-device-action@main
+      uses: equinix-labs/metal-device-action@v0.2.1
       continue-on-error: true
       with:
         metal_auth_token: ${{ steps.metal-project.outputs.projectToken }}
@@ -83,7 +83,7 @@ jobs:
         plan: m3.small.x86
         os: ubuntu_22_04
     - name: Delete temporary project & device
-      uses: equinix-labs/metal-sweeper-action@main
+      uses: equinix-labs/metal-sweeper-action@v0.6.1
       with:
         authToken: ${{ secrets.METAL_AUTH_TOKEN }}
         projectID: ${{ steps.metal-project.outputs.projectID }}
@@ -97,4 +97,3 @@ Before proceeding to the next part let's take a few minutes to discuss what we d
 
 * Are there other ways to create a GitHub Actions workflow for your repository?
 * How do you decide whether to configure a GitHub Actions secret or a GitHub Actions variable?
-

--- a/docs/parts/part3.md
+++ b/docs/parts/part3.md
@@ -64,4 +64,3 @@ Before proceeding to the next part let's take a few minutes to discuss what we d
 * Can you run additional tests on Equinix Metal resources before deleting them?
 * What other events can trigger a GitHub Actions workflow?
 * What kind of Equinix Metal resources can you create in a GitHub Actions workflow?
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Workshop: Equinix Labs"
 
-repo_url: https://github.com/equinix-labs/equinix-labs-workshop
-repo_name: equinix-labs/equinix-labs-workshop
+repo_url: https://github.com/equinix-labs/metal-github-actions-workshop
+repo_name: equinix-labs/metal-github-actions-workshop
 edit_uri: blob/main/docs
 
 extra_css:


### PR DESCRIPTION
This PR fixes the repo link in the workshop, adds links to the parts, and pins versions of the GH actions to the latest current tagged versions.

Fixes #10 

---

I did not make changes to the CONTRIBUTING.md, but I observed that it offers guidance for the upstream template project and not this descendent project.